### PR TITLE
Add last_modified_date_sort plug

### DIFF
--- a/_plugins/last_modified_date_sort.rb
+++ b/_plugins/last_modified_date_sort.rb
@@ -1,0 +1,15 @@
+module LastModifiedDateSort
+    def last_modified_date_sort(input, ascending=true)
+        input.sort_by { |post|
+            last_modified_at = Integer(post.fetch('last_modified_at').last_modified_at_unix)
+
+            if ascending then
+                last_modified_at
+            else
+                -last_modified_at
+            end
+        }
+    end
+end
+
+Liquid::Template.register_filter(LastModifiedDateSort)


### PR DESCRIPTION
# Context
For some reason it's not easy to sort posts using the `last_modified_at` field provided by `last_modified` Jekyll plugin. I suspect it might be because 
* last_modified_at on the `post` type is a class and not just a string (evidence by  `post.fetch('last_modified_at').last_modified_at_unix`)
* To use the `sort` liquid filter to you can't `sort` during a for loop - E.G ` for note in listOfNotes | sort` is invalid. 

I'm assuming the issue is because of the first thing I mentioned so this plugin aims to fix that. 

# This pull request
* Creates a Jekyll plugin that sorts a input of Jekyll posts by the `last_modified_at`  field on the post.  
  * By default it sorts in ascending order - you can optionally pass in a param of `false` to sort in descending (reverse) order. 

# How to use it
    * `{% assign listOfNotes = listOfNotes | last_modified_date_sort %}`
    * OR `{% assign listOfNotes = listOfNotes | last_modified_date_sort: false %}`
