### PR TITLE
Add support for sorting jekyll document types in last_modified_date_sort

### DIFF
--- a/_plugins/last_modified_date_sort.rb
+++ b/_plugins/last_modified_date_sort.rb
@@ -1,8 +1,16 @@
 module LastModifiedDateSort
     def last_modified_date_sort(input, ascending=true)
         input.sort_by { |post|
-            last_modified_at = Integer(post.fetch('last_modified_at').last_modified_at_unix)
 
+            last_modified_at = 0;
+            if post.instance_of? Jekyll::Document then
+                last_modified_at = Integer(post.data['last_modified_at'].last_modified_at_unix)
+            elsif post.instance_of? Jekyll::Drops::DocumentDrop then
+                last_modified_at = Integer(post.fetch('last_modified_at').last_modified_at_unix)
+            else
+                raise 'Unsupported date_sort class of type ' + post.class.to_s   
+            end
+            
             if ascending then
                 last_modified_at
             else


### PR DESCRIPTION
# Context
In #1 I added basic support for sorting posts with the `last_modified_at` field on them. What I didn't realize is that I added support for sorting `Jekyll::Drops::DocumentDrop` with the key `last_modified_date_sort` on them. It turns out that you can have arrays of other types - including `Jekyll::Document`! 😮 

# This PR
This PR addresses this (in maybe not the cleanest way) by doing a type check on the type of the elements in the array and depending on the type we get a different last_modified_at. In the case we get an unsupported type we will throw an error! Adding support for new classes should be easy to fix in the future!